### PR TITLE
fix: replace reference to window to permit using in web components

### DIFF
--- a/DynamicQuillTools.js
+++ b/DynamicQuillTools.js
@@ -91,7 +91,7 @@ class QuillToolbarDropDown extends QuillToolbarItem {
             qlPicker.classList.toggle('ql-expanded')
 
         })
-        window.addEventListener('click', function(e){
+        qlPicker.addEventListener('click', function(e){
             if (!qlPicker.contains(e.target)){
                 qlPicker.classList.remove('ql-expanded')
             }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "dynamicquilltools",
+  "version": "1.0.0",
+  "description": "DynamicQuillTools is a library that allows you to dynamically add or remove new custom elements to/from a Quill Editor's toolbar. For instance a button or a drop down menu.",
+  "main": "DynamicQuillTools.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/timblack-NukeDigital/DynamicQuillTools.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/timblack-NukeDigital/DynamicQuillTools/issues"
+  },
+  "homepage": "https://github.com/timblack-NukeDigital/DynamicQuillTools#readme"
+}


### PR DESCRIPTION
This change permits click events to be handled by the `QuillToolbarDropDown` when it is being used in a web component.

Before creating the `QuillToolbarDropDown` instance, it is also necessary to do the following to get the dropdown label to appear.

```javascript
    // Monkey patch to work in the shadow DOM
    QuillToolbarDropDown.prototype._addCssRule = (cssRule) => {
      const style = document.createElement("style");
      this.shadowRoot.appendChild(style);
      style.sheet.insertRule(cssRule, 0)
    }
```